### PR TITLE
Update cheat list with fee accrual context

### DIFF
--- a/cheat_list.md
+++ b/cheat_list.md
@@ -51,6 +51,7 @@
 
 ### Fee Accrual vs Claiming
 - `_accrueFees` only updates accounting variables; actual token transfers occur in `claimFees`.
+- Deposits or redeems after a snapshot do not alter fees. `_accrueFees` uses `Math.min` on unit price and total supply to compute TVL, isolating each accrual period. See `PriceAndFeeCalculator.sol` lines 332-369 and `DelayedFeeCalculator.sol` lines 68-90, 147-150.
 
 ### Validation Highlights
 - Token multipliers checked against min/max bounds.


### PR DESCRIPTION
## Summary
- clarify that deposits/redeems after a snapshot don't affect fee accrual

## Testing
- `make test` *(fails: forge not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6858ff83ece483288febdf815a187862