### PR TITLE
Add bridge transfer restriction prior knowledge

### DIFF
--- a/cheat_list.md
+++ b/cheat_list.md
@@ -63,3 +63,8 @@
 - Only callers with `requiresVaultAuth` may update the whitelist, preventing unauthorized freezes (line 25).
 - `beforeTransfer()` checks both parties against the whitelist; re-whitelisting restores transfer ability. See `TransferWhitelistHook.sol` lines 41-55.
 
+### Bridge Transfer Restrictions
+- `MultiDepositorVault._update` calls `hook.beforeTransfer(from, to, provisioner)` for every mint, burn, or transfer, ensuring hooks run for bridge operations. See `MultiDepositorVault.sol` lines 108-125.
+- `TransferWhitelistHook.beforeTransfer` validates both parties even when minting or burning. The non-`transferAgent` party must be whitelisted. See `TransferWhitelistHook.sol` lines 49-54.
+- `TransferBlacklistHook.beforeTransfer` blocks sanctioned addresses as `from` or `to` even during provisioner operations. See `TransferBlacklistHook.sol` lines 41-43.
+- Bridge contracts designated as provisioner therefore cannot mint or transfer vault units to restricted users.


### PR DESCRIPTION
## Summary
- document how transfer hooks prevent bridging from bypassing restrictions

## Testing
- `make lint` *(fails: forge not found)*
- `make test` *(fails: forge not found)*

------
https://chatgpt.com/codex/tasks/task_e_685904535364832891bb418f62b1394d