### PR TITLE
Add notes on fee claim caller context

### DIFF
--- a/cheat_list.md
+++ b/cheat_list.md
@@ -52,6 +52,11 @@
 ### Fee Accrual vs Claiming
 - `_accrueFees` only updates accounting variables; actual token transfers occur in `claimFees`.
 - Deposits or redeems after a snapshot do not alter fees. `_accrueFees` uses `Math.min` on unit price and total supply to compute TVL, isolating each accrual period. See `PriceAndFeeCalculator.sol` lines 332-369 and `DelayedFeeCalculator.sol` lines 68-90, 147-150.
+### Fee Claims Caller Context
+- `FeeVault.claimFees` invokes the calculator with the vault's balance. See `FeeVault.sol` lines 105-110.
+- `BaseFeeCalculator.claimFees` indexes `_vaultAccruals[msg.sender]` because the vault contract calls this function. See `BaseFeeCalculator.sol` lines 102-118.
+- Unit test `BaseFeeCalculator.t.sol` lines 188-198 calls `claimFees` with `vm.prank(BASE_VAULT)`, confirming the caller is the vault.
+
 
 ### Validation Highlights
 - Token multipliers checked against min/max bounds.


### PR DESCRIPTION
## Summary
- document how `claimFees` uses `msg.sender` and why

## Testing
- `make test` *(fails: forge not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6859091d02488328a913c6fef6eeed0c