### PR TITLE
Add cross-chain request behavior to cheat list

### DIFF
--- a/cheat_list.md
+++ b/cheat_list.md
@@ -72,3 +72,10 @@
 - `TransferWhitelistHook.beforeTransfer` validates both parties even when minting or burning. The non-`transferAgent` party must be whitelisted. See `TransferWhitelistHook.sol` lines 49-54.
 - `TransferBlacklistHook.beforeTransfer` blocks sanctioned addresses as `from` or `to` even during provisioner operations. See `TransferBlacklistHook.sol` lines 41-43.
 - Bridge contracts designated as provisioner therefore cannot mint or transfer vault units to restricted users.
+
+### Request Address Binding & Bridging Behavior
+- `struct Request` includes `address user` storing the caller at creation. See `Types.sol` lines 251-265.
+- `requestDeposit` and `requestRedeem` set the user to `msg.sender` via `_getRequestHashParams`. See `Provisioner.sol` lines 201-217 and 242-258.
+- `_solveDepositDirect` and `_solveRedeemDirect` always deliver assets to `request.user`. See `Provisioner.sol` lines 776-787 and 815-826.
+- CCTP bridging uses the vault address (`bytes32(uint160(address(vault)))`) as the cross-chain recipient, not user addresses. See `CCTPHooks.fork.t.sol` lines 147-156.
+


### PR DESCRIPTION
## Summary
- document how Provisioner binds requests to msg.sender
- clarify that direct solving sends assets to request.user
- note that CCTP bridging targets the vault address

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68590b8fd4c08328ba192eab8bbbfa00