### PR TITLE
Update cheat list with KyberSwap fee receiver constraint

### DIFF
--- a/cheat_list.md
+++ b/cheat_list.md
@@ -36,6 +36,12 @@
   2. updates and checks cumulative daily loss,
   3. resets daily counters when a new day starts.
 
+### KyberSwapDexHooks Fee Configuration
+- `_processSwapHooks` rejects any fee receivers:
+  `require(desc.feeReceivers.length == 0)` in `KyberSwapDexHooks.sol` lines 45-52.
+- The interface declares `error AeraPeriphery__FeeReceiversNotEmpty()` in `IKyberSwapDexHooks.sol` line 15.
+- Unit tests at `KyberSwapDexHooks.t.sol` lines 197-231 and 426-451 confirm swaps revert when fee receivers are provided.
+
 ### Deadline Validation
 - All solver functions verify `request.deadline >= block.timestamp` and refund expired requests.
 


### PR DESCRIPTION
## Summary
- document KyberSwapDexHooks requirement that `feeReceivers` array must be empty

## Testing
- `make test` *(fails: `forge: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6859107b88f8832891b2f1136e6e4e34