### PR TITLE
Update cheat list for transfer hook checks

### DIFF
--- a/cheat_list.md
+++ b/cheat_list.md
@@ -85,6 +85,7 @@
 - Only callers with `requiresVaultAuth` may update the whitelist, preventing unauthorized freezes (line 25).
 - `beforeTransfer()` checks both parties against the whitelist; re-whitelisting restores transfer ability. See `TransferWhitelistHook.sol` lines 41-55.
 - The two `require` statements operate independently. If `from` equals `transferAgent`, only the sender check is skipped; the recipient must still be whitelisted (and vice versa). See `TransferWhitelistHook.sol` lines 41-55 and `MultiDepositorVault.sol` lines 109-125.
+- `AbstractTransferHook.beforeTransfer` only enforces `isVaultUnitTransferable` when neither participant is the `transferAgent` nor `address(0)`. Derived hooks like `TransferWhitelistHook` and `TransferBlacklistHook` override this to validate the non-`transferAgent` address even during mint or burn. See `AbstractTransferHook.sol` lines 24-33, `TransferWhitelistHook.sol` lines 49-54, and `TransferBlacklistHook.sol` lines 41-43.
 
 ### Bridge Transfer Restrictions
 - `MultiDepositorVault._update` calls `hook.beforeTransfer(from, to, provisioner)` for every mint, burn, or transfer, ensuring hooks run for bridge operations. See `MultiDepositorVault.sol` lines 108-125.


### PR DESCRIPTION
## Summary
- note that `AbstractTransferHook.beforeTransfer` only checks transferability when neither party is the transfer agent nor address(0)
- specify derived hooks still validate the user address during mint/burn

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68591283bfd48328964fd1c67807527a