### PR TITLE
Update cheat list with solving auth info

### DIFF
--- a/cheat_list.md
+++ b/cheat_list.md
@@ -17,10 +17,10 @@
 
 ### Provisioner Request Flow
 - Users create requests via `requestDeposit` or `requestRedeem` transferring tokens/units to the Provisioner.
-- Vault solving (`solveRequestsVault`) mints/burns units through `enter()`/`exit()` using oracle-based pricing.
-- Direct solving supports only fixed-price requests and transfers existing units from solver to user.
+- Vault solving (`solveRequestsVault`) mints/burns units through `enter()`/`exit()` using oracle-based pricing and is restricted by `requiresAuth` (see `Provisioner.sol` line 294).
+- Direct solving supports only fixed-price requests and transfers existing vault units or tokens from the solver to `request.user`; no minting occurs (see `_solveDepositDirect` lines 776-782 and `_solveRedeemDirect` lines 816-820).
 - Deposit cap enforcement occurs only when vault units are minted. `deposit` and `mint` call `_requireDepositCapNotExceeded` before `_syncDeposit` (see `Provisioner.sol` lines 117-128 and 141-150). Vault-solving functions `_solveDepositVaultAutoPrice` and `_solveDepositVaultFixedPrice` check `_guardDepositCapExceeded` before calling `enter()` (lines 541-552 and 598-610). `_solveDepositDirect` merely transfers existing units without minting, so the cap is unchanged (lines 764-791).
-
+- The repository does not include any reward or incentivization contracts.
 - Solver tips are accumulated and paid once per batch.
 
 ### Fee Calculation


### PR DESCRIPTION
## Summary
- clarify that `solveRequestsVault` requires auth
- note that direct solving moves solver-owned assets and mints nothing
- mention missing reward systems

## Testing
- `make test` *(fails: forge not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68591628a4a48328b0c92583c9c25d3f