### PR TITLE
Add known issue about lack of user revocation

### DIFF
--- a/already_known.md
+++ b/already_known.md
@@ -1,0 +1,8 @@
+# Already Known Issues
+
+## Lack of User-Controlled Request Revocation
+
+- **Root cause**: `refundRequest()` only allows early cancellation when the caller is authorized. The original request creator cannot revoke before the deadline expires.
+- **Code reference**: [`Provisioner.sol` lines 262-266](./src/core/Provisioner.sol#L262-L266) enforce this restriction.
+- **Impact**: Pending requests remain executable by solvers until expiration, exposing users to unwanted executions if market conditions change.
+


### PR DESCRIPTION
## Summary
- document lack of self-service request revocation

## Testing
- `make lint` *(fails: forge not found)*
- `make test` *(fails: forge not found)*

------
https://chatgpt.com/codex/tasks/task_e_68591990b7508328956978c14668c130