### PR TITLE
Add whitelist enforcement note

### DIFF
--- a/cheat_list.md
+++ b/cheat_list.md
@@ -87,6 +87,7 @@
 - Only callers with `requiresVaultAuth` may update the whitelist, preventing unauthorized freezes (line 25).
 - `beforeTransfer()` checks both parties against the whitelist; re-whitelisting restores transfer ability. See `TransferWhitelistHook.sol` lines 41-55.
 - The two `require` statements operate independently. If `from` equals `transferAgent`, only the sender check is skipped; the recipient must still be whitelisted (and vice versa). See `TransferWhitelistHook.sol` lines 41-55 and `MultiDepositorVault.sol` lines 109-125.
+- `MultiDepositorVault._update` passes the vault's `provisioner` as the `transferAgent` when invoking `beforeTransfer`, so provisioner transfers still enforce whitelisting of the other party. See `MultiDepositorVault.sol` lines 108-115 and `TransferWhitelistHook.sol` lines 49-55. Unit tests verify that a call reverts when the recipient is not whitelisted (see `BeforeTransferWhitelistHooks.t.sol` lines 88-96).
 - `AbstractTransferHook.beforeTransfer` only enforces `isVaultUnitTransferable` when neither participant is the `transferAgent` nor `address(0)`. Derived hooks like `TransferWhitelistHook` and `TransferBlacklistHook` override this to validate the non-`transferAgent` address even during mint or burn. See `AbstractTransferHook.sol` lines 24-33, `TransferWhitelistHook.sol` lines 49-54, and `TransferBlacklistHook.sol` lines 41-43.
 
 ### Bridge Transfer Restrictions


### PR DESCRIPTION
## Summary
- document provisioner whitelist enforcement in cheat list

## Testing
- `make lint` *(fails: forge not found)*
- `make test` *(fails: forge not found)*

------
https://chatgpt.com/codex/tasks/task_e_68591b51978c8328964a1be0007860a0