### PR TITLE
Update cheat list with request hash details

### DIFF
--- a/cheat_list.md
+++ b/cheat_list.md
@@ -120,6 +120,12 @@
 - `execute()` checks `_canCall[msg.sender][targetAndSelector]` using only on-chain data; no off-chain signatures are involved. See `Forwarder.sol` lines 33-57.
 - Permissions must be granted separately per chain, so cross-chain replay attacks are not possible unless the owner intentionally duplicates permissions.
 
+### Request Hashing Without Signatures
+- `asyncDepositHashes` and `asyncRedeemHashes` store used request hashes per chain. See `Provisioner.sol` lines 62-72.
+- `_getRequestHashParams` and `_getRequestHash` compute `keccak256` over request parameters with no EIP‑712 domain. See `Provisioner.sol` lines 1005-1034.
+- `requestDeposit` and `requestRedeem` generate these hashes and mark them used. See `Provisioner.sol` lines 204-217 and 247-249.
+- Because no signatures are used, cross-chain domain separator vulnerabilities do not apply; each deployment tracks its own request hashes.
+
 ### Allowance Handling and Fee-on-Transfer Tokens
 - `requestDeposit` pulls tokens with `token.safeTransferFrom(msg.sender, address(this), tokensIn)`; allowances are enforced by the token. See `Provisioner.sol` lines 201-202.
 - `MultiDepositorVault.enter` similarly calls `token.safeTransferFrom(sender, address(this), tokenAmount)` before minting. See `MultiDepositorVault.sol` lines 67-71.


### PR DESCRIPTION
## Summary
- document Provisioner request hashing
- note absence of EIP-712 signatures to avoid domain separator false positives

## Testing
- `pre-commit` *(fails: command not found)*
- `make test` *(fails: forge not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68591cc128b083288cdeee376820e43b