### PR TITLE
Update cheat list with deposit lock behavior

### DIFF
--- a/cheat_list.md
+++ b/cheat_list.md
@@ -149,3 +149,8 @@
 93. () `MultiDepositorVault.enter` similarly calls `token.safeTransferFrom(sender, address(this), tokenAmount)` before minting. See `MultiDepositorVault.sol` lines 67-71.
 94. () Direct solving uses the same helpers: `_solveDepositDirect` (lines 776-781) and `_solveRedeemDirect` (lines 815-820) rely on `safeTransfer` and `safeTransferFrom`.
 95. () The protocol never modifies allowances; standard ERC-20 tokens deduct fees from the transferred amount, so allowances remain accurate. Tokens that remove extra tokens are non-compliant and outside the threat model.
+
+### Deposit Refund Timeout
+96. () `_syncDeposit` sets `refundableUntil = block.timestamp + depositRefundTimeout` and stores it in `userUnitsRefundableUntil[msg.sender]`. See `Provisioner.sol` lines 479-489.
+97. () Transfers query `areUserUnitsLocked` which returns `userUnitsRefundableUntil[user] >= block.timestamp`, so locks expire naturally when the timestamp passes. See `Provisioner.sol` lines 450-452.
+98. () `depositRefundTimeout` is configured via `setDepositDetails` and must not exceed `MAX_DEPOSIT_REFUND_TIMEOUT = 30 days`. See `Provisioner.sol` lines 384-395 and `Constants.sol` lines 140-143.


### PR DESCRIPTION
## Summary
- document how `userUnitsRefundableUntil` is set and used
- clarify expiration of refundable lock via `depositRefundTimeout`

## Testing
- `make test` *(fails: forge not found)*

------
https://chatgpt.com/codex/tasks/task_e_685933f53d248328a23510daff403237