### PR TITLE
Add bridge transfer lock clarification

### DIFF
--- a/cheat_list.md
+++ b/cheat_list.md
@@ -137,6 +137,11 @@
     49-54, and `TransferBlacklistHook.sol` lines 41-43. `MultiDepositorVault._update`
     passes the vault's provisioner as this `transferAgent` for every transfer
     (see `MultiDepositorVault.sol` lines 108-115).
+64a. () Because bridges use burn (`to == address(0)`) and mint (`from == address(0)`) calls,
+     both operations bypass the `isVaultUnitTransferable` check when the bridge
+     contract is the provisioner. Setting `isVaultUnitTransferable` to `false`
+     freezes only direct user transfers; provisioner-mediated bridging remains
+     functional unless restricted by whitelist or blacklist hooks.
 
 ### Bridge Transfer Restrictions
 65. () `MultiDepositorVault._update` calls `hook.beforeTransfer(from, to, provisioner)` for every mint, burn, or transfer, ensuring hooks run for bridge operations. See `MultiDepositorVault.sol` lines 108-125.


### PR DESCRIPTION
## Summary
- document that burn and mint operations bypass `isVaultUnitTransferable` when the bridge acts as provisioner

## Testing
- `make test` *(fails: forge not installed)*
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a362094008328b2cd267a65ed551b