### PR TITLE
Update cheat list with price staleness validation

### DIFF
--- a/cheat_list.md
+++ b/cheat_list.md
@@ -251,3 +251,11 @@
         reject the former guardian.
       - Unit test `BaseVault.t.sol` lines 183‑204 verifies successful
         revocation and event emission.
+
+### Price Update Staleness Validation
+118. () `_validatePriceUpdate` enforces that price timestamps are recent.
+    - Requires `timestamp > vaultPriceState.timestamp`.
+    - Requires `block.timestamp >= timestamp`.
+    - Requires `vaultPriceState.maxPriceAge != 0`.
+    - Requires `maxPriceAge + timestamp >= block.timestamp`.
+    See `PriceAndFeeCalculator.sol` lines 431-446.


### PR DESCRIPTION
## Summary
- add note explaining `_validatePriceUpdate` logic and staleness checks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a38fad9fc83288b66051d4b06030f