### PR TITLE
Add TVL fee free-riding note

### DIFF
--- a/already_known.md
+++ b/already_known.md
@@ -18,3 +18,9 @@
 - **Root cause**: `TransferWhitelistHook` stores whitelist status per chain with no synchronization, so bridged addresses remain unwhitelisted on other chains.
 - **Code reference**: [`TransferWhitelistHook.sol` lines 15-39](./src/periphery/hooks/transfer/TransferWhitelistHook.sol#L15-L39) define the mapping and update logic. The check in [`TransferWhitelistHook.sol` lines 49-54](./src/periphery/hooks/transfer/TransferWhitelistHook.sol#L49-L54) rejects unwhitelisted recipients.
 - **Impact**: Cross-chain transfers revert on the destination chain until the recipient is manually whitelisted there, potentially stranding assets.
+
+## TVL Fee Free-Riding via Same-Period Join and Exit
+
+- **Root cause**: `_accrueFees()` computes TVL using the minimum of current vs. last total supply and unit price. Depositing after a snapshot then redeeming before the next causes the larger intra-period supply to be ignored.
+- **Code reference**: [`PriceAndFeeCalculator.sol` lines 343-347](./src/core/PriceAndFeeCalculator.sol#L343-L347) show the `Math.min` logic.
+- **Impact**: Users can hold value for most of the period while avoiding TVL fees, shifting costs to long-term holders.


### PR DESCRIPTION
## Summary
- record known issue about TVL fee free-riding due to `Math.min` in `_accrueFees`

## Testing
- `make test` *(fails: `forge` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685a371f3d08832897b4067ec3d6dcbe