### PR TITLE
Update cheat list with pause revert info

### DIFF
--- a/cheat_list.md
+++ b/cheat_list.md
@@ -259,3 +259,8 @@
     - Requires `vaultPriceState.maxPriceAge != 0`.
     - Requires `maxPriceAge + timestamp >= block.timestamp`.
     See `PriceAndFeeCalculator.sol` lines 431-446.
+
+119. () `convertUnitsToTokenIfActive` and `convertTokenToUnitsIfActive` revert with `Aera__VaultPaused` when the vault is paused.
+    - These helpers enforce `require(!vaultState.paused, Aera__VaultPaused());` in `PriceAndFeeCalculator.sol` lines 246-256 and 278-289.
+    - Provisioner helpers such as `_unitsToTokensCeilIfActive` rely on them, so `solveRequestsVault` cannot mint or burn while paused.
+    - Unit tests `Provisioner.t.sol` lines 3053-3102 verify this behaviour.


### PR DESCRIPTION
## Summary
- document that PriceAndFeeCalculator conversion helpers revert when the vault is paused

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a358cfb848328a91b8ff5f00c75f4